### PR TITLE
Better fail states

### DIFF
--- a/waybacknews/searchapi.py
+++ b/waybacknews/searchapi.py
@@ -105,6 +105,7 @@ class SearchApiClient:
         more_pages = True
         while more_pages:
             page, response = self._query("{}/search/result".format(self._collection), params, method='POST')
+            print(page)
             if self._is_no_results(page):
                 yield []
             else:
@@ -134,6 +135,10 @@ class SearchApiClient:
             r = self._session.post(endpoint_url, json=params)
         else:
             raise RuntimeError("Unsupported method of '{}'".format(method))
+        
+        if(r.status_code >= 500):
+            raise RuntimeError("API Server Error: a bad query string could have triggered this. Params: {}".format(params))
+                               
         return r.json(), r
 
     @classmethod

--- a/waybacknews/tests/test_waybacknews.py
+++ b/waybacknews/tests/test_waybacknews.py
@@ -147,4 +147,10 @@ class TestMediaCloudCollection(TestCase):
                 assert len(article_info['snippet']) > 0
             break
 
-
+    def test_external_server_error(self):
+        err_url = "https://centralasia.media/news:1796533?from=rss".split("/")[-1].split("?")[0]
+        bad_query = f"url:*{err_url}*"
+        start_date = dt.datetime(2022, 8, 1)
+        end_date = dt.datetime(2022, 8, 5)
+        with self.assertRaises(RuntimeError):
+            next(self._api.all_articles(bad_query, start_date, end_date))


### PR DESCRIPTION
Changed the output of all_articles to look like the rest of the api when nothing is returned
Added an exception for the case when a query causes an internal server error on the api